### PR TITLE
Added nextAiringEpisode episode and timeUntilAiring to anime

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -8,7 +8,7 @@ module.exports = {
             season duration countryOfOrigin isLicensed source hashtag trailer { id site }
             updatedAt coverImage { large medium } bannerImage genres synonyms averageScore meanScore
             popularity trending tags { name isMediaSpoiler } relations { edges { id } } characters { edges { id } }
-            staff { edges { id } } studios { edges { id } } isFavourite isAdult nextAiringEpisode { id } airingSchedule { edges { id } }
+            staff { edges { id } } studios { edges { id } } isFavourite isAdult nextAiringEpisode { id episode timeUntilAiring } airingSchedule { edges { id } }
             trends { edges { node { averageScore popularity inProgress episode } } } externalLinks { url }
             streamingEpisodes { title thumbnail url site } rankings { id } mediaListEntry { id }
             reviews { edges { node { id summary } } } siteUrl autoCreateForumThread modNotes } }`, { id: id });


### PR DESCRIPTION
Since there was no way to get the next airing episode and time until it airs from the id (that I can think of), this can be useful.