### PR TITLE
Release 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Anilist.media.anime(21708).then(data => {
 
 ## Documentation
 Please see [documentation.md](documentation.md) file for more information
+
+## License and Contact
+AniList-Node is licensed under the [MIT License](LICENSE).
+
+For issues and bugs, please use the issue tracker on this repository. For other needs, either contact me by email <a href=katsurinstudios@protonmail.ch>katsurinstudios@protonmail.ch</a> or in my [Discord server](https://discord.gg/TJJ6KGd) in the #anilist-node channel.

--- a/documentation.md
+++ b/documentation.md
@@ -71,7 +71,7 @@ Names must be strings and ids must be numbers.
 
 ## General
 - `people.id` | Person's id
-- `people.name` | Person's name. Returns three values: first, last, native
+- `people.name` | Person's name. Returns three values: english, native, and alternative (alternatives being nicknames and titles)
 - `people.image` | Person's cover image. Returns two values: large and medium
 - `people.descriptions` | Person's description
 - `people.isFavourite` | [Requires login] Check if person is favourited
@@ -84,7 +84,7 @@ Names must be strings and ids must be numbers.
 ## Staff Unique
 - `staff.language` | Staff's language
 - `staff.staffMedia` | An array of ids and titles of all media that the staff has been apart of (Up to the first 25 on the list.)
-- `staff.characters` | An array of ids and names of all characters that the staff has voiced (Up to the first 25 on the list.)
+- `staff.characters` | An array of ids and the english names of all characters that the staff has voiced (Up to the first 25 on the list.)
 
 # Search
 - `Anilist.search(type, term, page, amount)` | Searches the database for an anime or manga that resembles the term provided.

--- a/documentation.md
+++ b/documentation.md
@@ -171,9 +171,11 @@ Usernames must be strings and ids must be numbers!<br/>
     - `entry.dates` | The dates related to that entry in ISO 8601 format. Gives four values per object: startedAt, completedAt, updatedAt and createdAt
 
 # Studio
-- `Anilist.studio(id)` | Get information on a studio by an id
+- `Anilist.studio(id|name)` | Get information on a studio by an id or its name
     - `studio.id` | The studio's id
     - `studio.name` | The studio's name
-    - `studio.media` | An array of ids of all of the media the studio has done.
+    - `studio.isAnimationStudio` | Boolean value of if the studio is an animation studio.
+    - `studio.favourites` | Number of people who have favourited the studio on AniList.
+    - `studio.media` | A list of all the media the studio has done (Up to the first 25 per AniList's limit). Returns two values per object: id and title
     - `studio.siteUrl` | Site url of the studio on Anilist
     - `studio.isFavourite` | Checks if the studio is favourited [Requires login]

--- a/documentation.md
+++ b/documentation.md
@@ -11,7 +11,6 @@ Upon using a function, the data it returns is given in an object. So within the 
 - `media.id` | The id of the media
 - `media.idMAL` | The MAL id of the media
 - `media.title` | Media title. Gives four values: romaji, English, native, userPreferred [Requires login for userPreferred]
-- `media.type` | Media type
 - `media.description` | Media description
 - `media.format` | Format of the media (ie: TV, OVA, Novel)
 - `media.status` | Current status of the media
@@ -29,8 +28,8 @@ Upon using a function, the data it returns is given in an object. So within the 
 - `media.meanScore` | Mean score of all the user's scores
 - `media.synonyms` | Media's alternative titles
 - `media.trends` | Media's daily trend status. An array of objects that gives four values per object: date, trending, popularity, and inProgress
-- `media.staff` | An array of staff credited in the media. Gives three values per object: id, name (string given as "first last"), and native (Native form of their name)
-- `media.characters` | An array of objects with two values per object: id and name (name is a string given as "first last")
+- `media.staff` | An array of credited staff. Gives two values per object: id and their name (string given as "first last")
+- `media.characters` | An array of characters with two values per object: id and their name (string given as "first last")
 - `media.reviews` | An array of objects. Gives four values per object: id, score, summary, and body (main text of the review)
 - `media.popularity` | The number of users with the media on their list
 - `media.trending` | The amount of related activity in the past week.
@@ -45,10 +44,13 @@ Upon using a function, the data it returns is given in an object. So within the 
 - `media.recommendations` | An array of recommendations
 - `media.recommendations.id` | The ID of the show recommended. 
 - `media.recommendations.title` | An object of the show's titles. Four values: romanji, english, native, and userPreferred.
+- `media.stats.scoreDistribution` | An array of how the users have rated the media. Each object contains a score and amount.
+- `media.stats.statusDistribution` | An array of the users status with the show. Each object contains a status and amount.
 
 ## Anime Unique
 - `anime.episodes` | Number of episodes
 - `anime.season` | Season that the anime started airing
+- `anime.seasonYear` | The season year that the anime started airing
 - `anime.duration` | General length of an episode
 - `anime.hashtag` | Twitter hashtag associated with the anime
 - `anime.trailer` | Returns the trailer URL if the trailer is a Youtube or Dailymotion video. Will default to the object if it's not.

--- a/documentation.md
+++ b/documentation.md
@@ -28,8 +28,8 @@ Upon using a function, the data it returns is given in an object. So within the 
 - `media.meanScore` | Mean score of all the user's scores
 - `media.synonyms` | Media's alternative titles
 - `media.trends` | Media's daily trend status. An array of objects that gives four values per object: date, trending, popularity, and inProgress
-- `media.staff` | An array of credited staff. Gives two values per object: id and their name (string given as "first last")
-- `media.characters` | An array of characters with two values per object: id and their name (string given as "first last")
+- `media.staff` | An array of credited staff. Gives two values per object: id and their name (given as "first last")
+- `media.characters` | An array of characters with two values per object: id and their name (given as "first last")
 - `media.reviews` | An array of objects. Gives four values per object: id, score, summary, and body (main text of the review)
 - `media.popularity` | The number of users with the media on their list
 - `media.trending` | The amount of related activity in the past week.
@@ -120,7 +120,9 @@ Usernames must be strings and ids must be numbers!<br/>
 - `profile.bannerImage` | User's banner image
 - `profile.isFollowing` | [Requires login] Checks if the logged in user is following the user
 - `profile.options` | User's options. Returns four values: titleLanguage, displayAdultContent, airingNotifications, profileColor
-- `profile.mediaListOptions` | Undocumented. Returns five values: scoreFormat, rowOrder, useLegacyLists, sharedTheme, sharedThemeEnabled
+- `profile.mediaListOptions` | Undocumented. Returns five values: scoreFormat, rowOrder, useLegacyLists, animeList, mangaList
+- `profile.mediaListOptions.animeList` | User's anime list options. Returns five values: sectionOrder, splitCompletedSectionByFormat, customLists, advancedScoring, advancedScoringEnabled.
+- `profile.mediaListOptions.mangaList` | User's manga list options. Returns five values: sectionOrder, splitCompletedSectionByFormat, customLists, advancedScoring, advancedScoringEnabled.
 - `profile.unreadNotificationCount` | Amount of unreadNotifications the user has
 - `profile.siteUrl` | User's AniList URL
 - `profile.donatorTier` | Check if the user is a donator
@@ -128,25 +130,53 @@ Usernames must be strings and ids must be numbers!<br/>
 - `profile.updatedAt` | Timestamp of the last update of the user
 - `profile.isFollower` | [Requires login] Checks if the searched user is following the logged in user.
 - `profile.isBlocked` | [Requires login] Checks if the logged in user has blocked the searched user.
+- `profile.bans` | Record of user's bans.
 
-## Stats Unique
-- `stats.watchedTime` | Total amount of watch time on the user's anime list
-- `stats.chaptersRead` | Total amount of chapters read on the user's manga list
-- `stats.activityHistory` | The activity history of the user. Returns three values: date, amount, level
-- `stats.animeStatusDistribution` | Undocumented. Returns two values: status and amount
-- `stats.mangaStatusDistribution` | Undocumented. Returns two values: status and amount
-- `stats.animeScoreDistribution` | Undocumented. Returns two values: score and amount
-- `stats.mangaScoreDistribution` | Undocumented. Returns two values: score and amount
-- `stats.animeListScores` | Undocumented. Returns two values: meanScore and standardDeviation
-- `stats.mangaListScores` | Undocumented. Returns two values: meanScore and standardDeviation
-- `stats.favouredGenresOverview` | Undocumented. Returns four values: genre, amount, meanScore, timeWatched
-- `stats.favouredGenres` | List of the user's favourite genres. Gives four values per object: genre, amount, meanScore, timeWatched
-- `stats.favouredTags` | List of the user's favourite tags. Gives four values per object: tag.name, amount, meanScore, timeWatched
-- `stats.favouredActors` | List of the user's favourite actors. Gives three values per object: staff.id, amount, meanScore, timeWatched
-- `stats.favouredStaff` | List of the user's favourite staff. Gives three values per object: staff.id, amount, meanScore, timeWatched
-- `stats.favouredStudios` | List of the user's favourite studios. Gives three values per object: studio.name, amount, meanScore, timeWatched
-- `stats.favouredYears` | List of the user's favourite years. Gives three values per object: year, amount, meanScore
-- `stats.favouredFormats` | List of the user's favourite formats. Gives two values per object: format, amount
+### User's Favourites
+Fetched through `profile.favourites`
+
+- `favourites.anime` | An array of all user's favourite anime. Returns two values: id and title.
+- `favourites.manga` | An array of all user's favourite manga. Returns two values: id and title.
+- `favourites.characters` | An array of all user's favourite characters. Returns two values: id and name (given "first last")
+- `favourites.staff` | An array of all user's favourite staff. Returns two values: id and name (given "first last")
+- `favourites.studios` | An array of all user's favourite studios. Returns two values: id and name
+
+### User's Statistics
+Fetched through `profile.statistics`. Returns two objects: anime and manga.
+
+- `statistics.[type].meanScore` | Mean score of all entries with the type.
+- `statistics.[type].standardDeviation` | The standard deviation of all scores with all entries with the type.
+- `statistics.[type].count` | Total amount of entries with the type.
+
+#### Statistics Across Various Fields.
+All of these types will return an object with four keys: 
+
+    > count and meanScore are included across all fields
+    > watchedTime is included for all anime specific fields.
+    > chaptersRead is included for all manga specific fields.
+    > one additional key, specified in each description pertaining to the entry.
+
+> Note that any item will only appear in the list if the user has a count of two or more items
+
+- `statistics.[type].statuses` | A list of the user's statistics across various statuses. Unique key: status
+- `statistics.[type].formats` | A list of the user's statistics across various formats. Unique key: format
+- `statistics.[type].lengths` | A list of the user's statistics across various lengths. Unique key: length
+- `statistics.[type].releaseYears` | A list of the user's statistics across various release years. Unique key: releaseYear
+- `statistics.[type].startYears` | A list of the user's statistics across years where the user started the entry. Unique key: startYear
+- `statistics.[type].genres` | A list of the user's statistics across various genres. Unique key: genre
+- `statistics.[type].tags` | A list of the user's statistics across various tags. Unique key: tag (tag returns two values: id and name)
+- `statistics.[type].countries` | A list of the user's statistics across various countries. Unique key: country
+- `statistics.[type].staff` | A list of the user's statistics across various staff. Unique key: staff (staff returns two values: id and name)
+
+#### Anime Unique
+- `statistics.anime.watchedTime` | Total amount of watch time on the user's anime lists.
+- `statistics.anime.episodesWatched` | Total amount of episodes watched on the user's anime lists. 
+- `statistics.anime.voiceActors` | A list of the user's statistics across various voice actors. Unique key: voiceActor (voiceActor returns two values: id and name)
+- `statistics.anime.studios` | A list of the user's statistics across various studios. Unique key: studio (studio returns two values: id and name)
+
+#### Manga Unique
+- `statistics.manga.chaptersRead` | Total amount of chapters read on the user's manga lists.
+- `statistics.manga.volumesRead` | Total amount of volumes read of the user's manga lists.
 
 # Lists
 Usernames must be strings and ids must be numbers!<br/>

--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ module.exports = class AniList {
         var search = {
             "anime": "media (type: ANIME, search: $search) { id title { romaji english native userPreferred } }",
             "manga": "media (type: MANGA, search: $search) { id title { romaji english native userPreferred } }",
-            "char": "characters (search: $search) { id name { first last native } }" ,
-            "staff": "staff (search: $search) { id name { first last native } }",
+            "char": "characters (search: $search) { id name { full native } }" ,
+            "staff": "staff (search: $search) { id name { full native } }",
             "studio": "studios (search: $search) { id name }"
         }
 

--- a/index.js
+++ b/index.js
@@ -16,14 +16,18 @@ module.exports = class AniList {
 
     /**
      * Grabs data on a studio
-     * @param {Number} id - The studio ID on AniList.
+     * @param {String | Number} id - The studio ID or name on AniList.
      * @returns { Object } Returns a customized data object.
      */
     studio(id) {
         if (!id) { throw new Error("Studio id is not provided."); }
-        if (typeof id !== "number") { throw new Error("Term provided is not a number!"); }
 
-        return Fetch.send(`query($id: Int) { Studio(id: $id) { id name media { edges { id } } siteUrl isFavourite } }`, { id: id });
+        if (typeof id === "string") { var queryVars = [{ search: id }, "query ($search: String) { Studio (search: $search) { "]; }
+        else if (typeof id === "number") { var queryVars = [{ id: id }, "query ($id: Int) { Studio (id: $id) { "]; } 
+        else { throw new Error("Term does not match the required types!"); }
+
+        return Fetch.send(queryVars[1] + `id name isAnimationStudio siteUrl isFavourite favourites 
+            media { nodes { id title { romaji english native userPreferred } } } } }`, queryVars[0]);
     };
 
     /**

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -110,7 +110,7 @@ module.exports = {
             return json.data.Page;
         }
         else if (json.data.Studio) {
-            json.data.Studio.media = await edgeRemove(json.data.Studio.media.edges);
+            json.data.Studio.media = await edgeRemove(json.data.Studio.media.nodes);
             return json.data.Studio;
         } else if (json.data.User) {
             if (json.data.User.stats && !json.data.User.avatar) { 

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -133,6 +133,6 @@ module.exports = {
             return json.data.MediaListCollection.lists;
         }
 
-        return json.data; //If nothing matches, return collected data,
+        return json.data; //If nothing matches, return collected data
     }
 };

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -1,6 +1,19 @@
 const fetch = require("node-fetch");
 
 /**
+ * Edit a person's name data object for better use.
+ * @param { Object } obj - A name object of the person. 
+ */
+function nameEditor(obj) {
+    if (obj.alternative.length < 1 || obj.alternative[0] == "") { obj.alternative = null; }
+
+    obj.english = obj.full;
+    delete obj.full;
+
+    return obj;
+}
+
+/**
  * Moves data up levels in the object for better use.
  * @param { Object } obj - Required. The object to edit.
  * @returns { Object } Returns the edited object. 
@@ -8,18 +21,15 @@ const fetch = require("node-fetch");
 function edgeRemove(obj) {
     var list = [];
     for (var x = 0; x < obj.length; x++) {
-        if (obj[x].name) {
-            if (obj[x].name.native) { obj[x].native = obj[x].name.native; }
-            if (obj[x].name.last === null) { obj[x].name = obj[x].name.first; }
-            else if (obj[x].name.first === null) { obj[x].name = obj[x].name.last; }
-            else { obj[x].name = obj[x].name.first + " " + obj[x].name.last; }
-        }
+        if (obj[x].name) { obj[x].name = obj[x].name.full; }
 
         if (obj[x].node) { list.push(obj[x].node); }
         else if (obj[x].id && obj[x].length === 1) { list.push(obj[x].id); }
         else if (obj[x].url) { list.push(obj[x].url); }
         else { list.push(obj[x]); }
     }; 
+
+    if (list.length < 1) { list = null; }
     return list;
 }
 
@@ -87,9 +97,11 @@ module.exports = {
         if (json.data.Media) {
             return await formatMedia(json.data.Media);
         } else if (json.data.Character) {
+            json.data.Character.name = await nameEditor(json.data.Character.name);
             json.data.Character.media = json.data.Character.media.nodes;
             return json.data.Character;
         } else if (json.data.Staff) {
+            json.data.Staff.name = await nameEditor(json.data.Staff.name);
             json.data.Staff.staffMedia = await edgeRemove(json.data.Staff.staffMedia.nodes);
             json.data.Staff.characters = await edgeRemove(json.data.Staff.characters.nodes);
             if (json.data.Staff.description.length < 1) { json.data.Staff.description = null; }

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -113,9 +113,21 @@ module.exports = {
             json.data.Studio.media = await edgeRemove(json.data.Studio.media.nodes);
             return json.data.Studio;
         } else if (json.data.User) {
-            if (json.data.User.stats && !json.data.User.avatar) { 
-                return json.data.User.stats; 
+            if (json.data.User.statistics) { //Move all names up a level.
+                json.data.User.statistics.anime.staff.forEach(e => { e.staff.name = e.staff.name.full; });
+                json.data.User.statistics.anime.voiceActors.forEach(e => { e.voiceActor.name = e.voiceActor.name.full });
+                json.data.User.statistics.manga.staff.forEach(e => { e.staff.name = e.staff.name.full; });
             }
+
+            if (json.data.User.statistics && !json.data.User.avatar) { return json.data.User.statistics; }
+
+            //Move all node objects up one level.
+            json.data.User.favourites.anime = json.data.User.favourites.anime.nodes;
+            json.data.User.favourites.manga = json.data.User.favourites.manga.nodes;
+            json.data.User.favourites.characters = await edgeRemove(json.data.User.favourites.characters.nodes);
+            json.data.User.favourites.staff = await edgeRemove(json.data.User.favourites.staff.nodes);
+            json.data.User.favourites.studios = json.data.User.favourites.studios.nodes;
+
             return json.data.User;
         } else if (json.data.MediaListCollection) {
             json.data.MediaListCollection.lists.forEach(list => {

--- a/lib/lists.js
+++ b/lib/lists.js
@@ -21,7 +21,7 @@ module.exports = {
             endDate { year month day } season duration countryOfOrigin isLicensed source hashtag trailer { id site } updatedAt coverImage { large medium } 
             bannerImage genres synonyms averageScore meanScore popularity trending tags { name isMediaSpoiler } 
             relations { nodes { id idMal title { english native romaji userPreferred } type format } } 
-            characters { nodes { id name { first last } } } staff { nodes { id name { first last native } } } studios { nodes { id name } } 
+            characters { nodes { id name { full } } } staff { nodes { id name { full native } } } studios { nodes { id name } } 
             isFavourite isAdult nextAiringEpisode { timeUntilAiring airingAt } airingSchedule { nodes { airingAt timeUntilAiring } }
             trends { nodes { date trending popularity inProgress } } externalLinks { url }
             streamingEpisodes { title thumbnail url site } rankings { id } mediaListEntry { id }
@@ -45,7 +45,7 @@ module.exports = {
             type description format status startDate { year month day } endDate { year month day } volumes countryOfOrigin isLicensed updatedAt
             coverImage { large medium } bannerImage genres synonyms averageScore meanScore siteUrl autoCreateForumThread modNotes
             popularity trending tags { name isMediaSpoiler } relations { nodes { id idMal title { english native romaji userPreferred } type format } }
-            characters { nodes { id name { first last } } } staff { nodes { id name { first last native } } } isFavourite isAdult 
+            characters { nodes { id name { full } } } staff { nodes { id name { full native } } } isFavourite isAdult 
             trends { nodes { date trending popularity inProgress } } externalLinks { url } rankings { id } 
             mediaListEntry { id } reviews { nodes { id score summary body } } }
             userId status score progress progressVolumes repeat priority private notes hiddenFromStatusLists

--- a/lib/media.js
+++ b/lib/media.js
@@ -1,4 +1,4 @@
-const { send } = require('./fetcher');
+const { send } = require("./fetcher");
 
 module.exports = {
     /**
@@ -11,15 +11,16 @@ module.exports = {
         if (typeof id !== "number") { throw new Error("Term provided is not a number!"); }
 
         return send(`query ($id: Int) { Media (id: $id, type: ANIME) { id idMal title { romaji english native userPreferred } 
-            type episodes description format status startDate { year month day } endDate { year month day }
-            season duration countryOfOrigin isLicensed source hashtag trailer { id site }
+            format status episodes description startDate { year month day } endDate { year month day }
+            season seasonYear duration countryOfOrigin isLicensed source hashtag trailer { id site }
             updatedAt coverImage { large medium } bannerImage genres synonyms averageScore meanScore
             popularity trending tags { name isMediaSpoiler } relations { nodes { id idMal title { english native romaji userPreferred } type format } } 
-            characters { nodes { id name { first last } } } staff { nodes { id name { first last native } } } studios { nodes { id name } } 
+            characters { nodes { id name { full } } } staff { nodes { id name { full } } } studios { nodes { id name } } 
             isFavourite isAdult nextAiringEpisode { timeUntilAiring airingAt } airingSchedule { nodes { airingAt timeUntilAiring } }
             trends { nodes { date trending popularity inProgress } } externalLinks { url }
             streamingEpisodes { title thumbnail url site } rankings { id } mediaListEntry { id }
             reviews { nodes { id score summary body } } siteUrl autoCreateForumThread modNotes 
+            stats { scoreDistribution { score amount } statusDistribution { status amount } }
             isRecommendationBlocked recommendations { nodes { mediaRecommendation { id title { romaji english native userPreferred } } } } } }`, { id: id });
     },
     /**
@@ -32,12 +33,13 @@ module.exports = {
         if (typeof id !== "number") { throw new Error("Term provided is not a number!"); }
 
         return send(`query ($id: Int) { Media (id: $id, type: MANGA) { id idMal title { romaji english native userPreferred }
-            type description format status startDate { year month day } endDate { year month day } chapters volumes countryOfOrigin isLicensed updatedAt
+            description format status startDate { year month day } endDate { year month day } chapters volumes countryOfOrigin isLicensed updatedAt
             coverImage { large medium } bannerImage genres synonyms averageScore meanScore siteUrl autoCreateForumThread modNotes
             popularity trending tags { name isMediaSpoiler } relations { nodes { id idMal title { english native romaji userPreferred } type format } }
-            characters { nodes { id name { first last } } } staff { nodes { id name { first last native } } } isFavourite isAdult 
+            characters { nodes { id name { full } } } staff { nodes { id name { full } } } isFavourite isAdult 
             trends { nodes { date trending popularity inProgress } } externalLinks { url } rankings { id } 
             mediaListEntry { id } reviews { nodes { id score summary body } } 
+            stats { scoreDistribution { score amount } statusDistribution { status amount } }
             isRecommendationBlocked recommendations { nodes { mediaRecommendation { id title { romaji english native userPreferred } } } } } }`, { id: id });
     }
 };

--- a/lib/people.js
+++ b/lib/people.js
@@ -1,4 +1,4 @@
-const { send } = require('./fetcher');
+const { send } = require("./fetcher");
 
 module.exports = {
     /**
@@ -9,12 +9,12 @@ module.exports = {
     character: function(id) {
         if (!id) { throw new Error("Character term is not provided!"); }
 
-        if (typeof id === 'string') { queryVars = [{ search: id }, `query ($search: String) { Character (search: $search) { `]; }
-        else if (typeof id === 'number') { queryVars = [{ id: id }, `query ($id: Int) { Character (id: $id,) { `]; }
+        if (typeof id === "string") { queryVars = [{ search: id }, "query ($search: String) { Character (search: $search) { "]; }
+        else if (typeof id === "number") { queryVars = [{ id: id }, "query ($id: Int) { Character (id: $id) { "]; }
         else { throw new Error("Term does not match the required types!"); }
 
-        return send(queryVars[1] + `id name { first last native } image { large medium } description isFavourite favourites 
-        siteUrl media { nodes { id idMal title { romaji english native userPreferred } format } } } }`, queryVars[0]);
+        return send(queryVars[1] + `id name { full native alternative } image { large medium } description isFavourite favourites 
+        siteUrl media { nodes { id title { romaji english native userPreferred } format } } } }`, queryVars[0]);
     },
     /**
      * Fetch a staff entry by its AniList ID or their name.
@@ -27,10 +27,10 @@ module.exports = {
         if (typeof id === 'string') { queryVars = [{ search: id }, `query ($search: String) { Staff (search: $search) { `]; }
         else if (typeof id === 'number') { queryVars = [{ id: id }, `query ($id: Int) { Staff (id: $id,) { `]; }
         else { throw new Error("Term does not match the required types!"); }
-        
-        return send(queryVars[1] + `id name { first last native } language image { large medium }
+
+        return send(queryVars[1] + `id name { full native alternative } language image { large medium }
             description isFavourite siteUrl favourites
             staffMedia { nodes { id title { romaji english native userPreferred } } }
-            characters { nodes { id name { first last } } } } }`, queryVars[0]);
+            characters { nodes { id name { full } } } } }`, queryVars[0]);
     }
 };

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,4 +1,4 @@
-const { send } = require('./fetcher');
+const { send } = require("./fetcher");
 
 /**
  * Fetch a character entry by its AniList ID.
@@ -6,9 +6,48 @@ const { send } = require('./fetcher');
  * @returns { Object } Returns a customized data object.
  */
 function variables(user) {
-    if (typeof user === 'string') { return [{ name: user }, `query ($name: String) { User (name: $name) { `]; }
-    else if (typeof user === 'number') { return [{ id: user }, `query ($id: Int) { User (id: $id) { `]; } 
+    if (typeof user === "string") { return [{ name: user }, "query ($name: String) { User (name: $name) { "]; }
+    else if (typeof user === "number") { return [{ id: user }, "query ($id: Int) { User (id: $id) { "]; } 
 }
+
+//Queries for each specific function. Stored in variables here to remove redunant queries.
+var profileQuery = `id name about avatar { large medium } bannerImage isFollowing isFollower isBlocked
+bans options { titleLanguage displayAdultContent airingNotifications profileColor }
+mediaListOptions { scoreFormat rowOrder useLegacyLists 
+    animeList { sectionOrder splitCompletedSectionByFormat customLists advancedScoring advancedScoringEnabled }
+    mangaList { sectionOrder splitCompletedSectionByFormat customLists advancedScoring advancedScoringEnabled } } 
+favourites {
+    anime { nodes { id title { romaji english native userPreferred } } }
+    manga { nodes { id title { romaji english native userPreferred } } }
+    characters { nodes { id name { full } } }
+    staff { nodes { id name { full } } }
+    studios { nodes { id name } } }
+unreadNotificationCount siteUrl donatorTier moderatorStatus updatedAt`;
+
+var statsQuery = `statistics { anime {
+    meanScore standardDeviation count minutesWatched episodesWatched
+    statuses { count meanScore minutesWatched status }
+    formats { count meanScore minutesWatched format }
+    lengths { count meanScore minutesWatched length }
+    releaseYears { count meanScore minutesWatched releaseYear }
+    startYears { count meanScore minutesWatched startYear }
+    genres { count meanScore minutesWatched genre }
+    tags { count meanScore minutesWatched tag { id name } }
+    countries { count meanScore minutesWatched country }
+    voiceActors { count meanScore minutesWatched voiceActor { id name { full } } }
+    staff { count meanScore minutesWatched staff { id name { full } } }
+    studios { count meanScore minutesWatched studio { id name } } }
+manga {
+    meanScore standardDeviation count chaptersRead volumesRead
+    statuses { count meanScore chaptersRead status }
+    formats { count meanScore chaptersRead format }
+    lengths { count meanScore chaptersRead length }
+    releaseYears { count meanScore chaptersRead releaseYear }
+    startYears { count meanScore chaptersRead startYear }
+    genres { count meanScore chaptersRead genre }
+    tags { count meanScore chaptersRead tag { id name } }
+    countries { count meanScore chaptersRead country }
+    staff { count meanScore chaptersRead staff { id name { full } } } } }`;
 
 module.exports = {
     /**
@@ -21,11 +60,7 @@ module.exports = {
         if (typeof user !== "string" && typeof user !== "number") { throw new Error("Term provided is not a string or a number!"); }
 
         var start = variables(user);
-        var query = start[1] + `id name about avatar { large medium } bannerImage isFollowing isFollower isBlocked
-        options { titleLanguage displayAdultContent airingNotifications profileColor }
-        mediaListOptions { scoreFormat rowOrder useLegacyLists sharedTheme sharedThemeEnabled }
-        unreadNotificationCount siteUrl donatorTier moderatorStatus updatedAt } }`;
-        return send(query, start[0]);
+        return send(`${start[1]}${profileQuery}}}`, start[0]);
     },
     /**
      * Fetch a user's AniList stats.
@@ -37,14 +72,7 @@ module.exports = {
         if (typeof user !== "string" && typeof user !== "number") { throw new Error("Term provided is not a string or a number!"); }
 
         var start = variables(user);
-        var query = start[1] + `stats { watchedTime chaptersRead activityHistory { date amount level } animeStatusDistribution { status amount } 
-            mangaStatusDistribution { status amount } animeScoreDistribution { score amount } mangaScoreDistribution { score amount }
-            animeListScores { meanScore standardDeviation } mangaListScores { meanScore standardDeviation }
-            favouredGenresOverview { genre amount meanScore timeWatched } favouredGenres { genre amount meanScore timeWatched }
-            favouredTags { tag { name } amount meanScore timeWatched } favouredActors { staff { id } amount meanScore timeWatched }
-            favouredStaff { staff { id } amount meanScore timeWatched } favouredStudios { studio { name } amount meanScore timeWatched }
-            favouredYears { year amount meanScore } favouredFormats { format amount } } } }`;
-        return send(query, start[0]);
+        return send(`${start[1]}${statsQuery}}}`, start[0]);
     },
     /**
      * Fetch a user's AniList profile, basic and stats.
@@ -56,16 +84,6 @@ module.exports = {
         if (typeof user !== "string" && typeof user !== "number") { throw new Error("Term provided is not a string or a number!"); }
 
         var start = variables(user);
-        var query = start[1] + `id name about avatar { large medium } bannerImage isFollowing isFollower isBlocked
-        stats { watchedTime chaptersRead activityHistory { date amount level } animeStatusDistribution { status amount }
-            mangaStatusDistribution { status amount } animeScoreDistribution { score amount } mangaScoreDistribution { score amount }
-            animeListScores { meanScore standardDeviation } mangaListScores { meanScore standardDeviation } favouredGenresOverview { genre amount meanScore timeWatched }
-            favouredGenres { genre amount meanScore timeWatched } favouredTags { tag { name } amount meanScore timeWatched }
-            favouredActors { staff { id } amount meanScore timeWatched } favouredStaff { staff { id } amount meanScore timeWatched }
-            favouredStudios { studio { name } amount meanScore timeWatched } favouredYears { year amount meanScore } favouredFormats { format amount } } 
-        options { titleLanguage displayAdultContent airingNotifications profileColor }
-        mediaListOptions { scoreFormat rowOrder useLegacyLists sharedTheme sharedThemeEnabled } unreadNotificationCount
-        siteUrl donatorTier moderatorStatus updatedAt } }`;
-        return send(query, start[0]);
+        return send(`${start[1]}${profileQuery} ${statsQuery}}}`, start[0]);
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "anilist-node",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anilist-node",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "A lightweight Node.js wrapper for the AniList API",
   "main": "index.js",
   "scripts": {

--- a/tests/peopleTest.js
+++ b/tests/peopleTest.js
@@ -5,7 +5,7 @@ const anilist = new AnilistNode();
 anilist.people.staff(95672).then(data => { console.log(data); });
 
 //Finds staff via their names.
-anilist.people.staff("Kaiji Yuki").then(data => { console.log(data); });
+anilist.people.staff("Yuuki Kaji").then(data => { console.log(data); });
 
 //Finds a character via their Anilist ID
 anilist.people.character(88344).then(data => { console.log(data); });

--- a/tests/studioTest.js
+++ b/tests/studioTest.js
@@ -1,0 +1,8 @@
+const AnilistNode = require("../index.js");
+const anilist = new AnilistNode();
+
+//Find studio via their Anilist ID
+anilist.studio(314).then(data => { console.log(data); });
+
+//Find studio via their AniList name
+anilist.studio("White Fox").then(data => { console.log(data); });


### PR DESCRIPTION
# Added

Characters and staff now return alternative names
Users can now search studios by their names
Studio now returns favourites and isAnimationStudio
Media now returns score and status distribution
User.mediaListOptions now has two new keys: animeList and mangaList.
A user's bans and favourites are now accessible.

# Modifications

Characters and staff now return a value "english" instead of "first" and "last". The name is provided like on the site, "First Last"
Studio's media list now returns titles as well as IDs.
User statistics will now return a more accurate, more current, and much more user statistics from the site.

# Removed

Media will no longer fetch type of media within an anime or manga search.
User.stats is depreciated. Migrated to the new User.statistics