### PR TITLE
Update Query

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -15,7 +15,7 @@ module.exports = {
             season seasonYear duration countryOfOrigin isLicensed source hashtag trailer { id site }
             updatedAt coverImage { large medium } bannerImage genres synonyms averageScore meanScore favourites
             popularity trending tags { name isMediaSpoiler } relations { nodes { id idMal title { english native romaji userPreferred } type format } } 
-            characters { nodes { id name { full } } } staff { nodes { id name { full } } } studios { nodes { id name } } 
+            characters { nodes { id name { full } } } staff { nodes { id name { full } } } studios { nodes { id name isAnimationStudio} } 
             isFavourite isAdult nextAiringEpisode { timeUntilAiring airingAt episode } airingSchedule { nodes { airingAt timeUntilAiring episode } }
             trends { nodes { date trending popularity inProgress } } externalLinks { url }
             streamingEpisodes { title thumbnail url site } rankings { rank type context year season } mediaListEntry { id status }


### PR DESCRIPTION
I should have checked for this before making the previous pull request. Sorry for that! 
However, here I have added isAnimationStudio to Studios. 
It's useful when you want the studio that animated the anime. Otherwise, sometimes even a licensor is sometimes returned as the first Object in Studio. 