### PR TITLE
fix: fetch.AbortError is not defined

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -141,7 +141,7 @@ module.exports = {
 
 		const response = await fetch("https://graphql.anilist.co", options)
 			.catch((error) => {
-				if (error instanceof fetch.AbortError) {
+				if (error.name === "AbortError") {
 					throw new Error(`ERROR: Request timed out after ${this.options.timeout}ms, is AniList up?`);
 				}
 			})


### PR DESCRIPTION
## Description
Fixes an issue where if the request times out, it doesn't return a proper error

## Related Issue
none

## Other Information:
fetcher.AbortError is not a thing, so when checking with instanceof, it throws an error, this means that the timeout logic still worked, but it wouldn't return a "ERROR: Request timed out after `x`ms, is AniList up?" message