### PR TITLE
[Fix/789, Fix/790, Fix/747] Update Typings + Fixed Response Catch

### DIFF
--- a/lib/docDefinition.js
+++ b/lib/docDefinition.js
@@ -148,6 +148,8 @@
  * @property { Boolean } isAdult - Check if the media is for adult audiences (ie: Hentai)
  * @property { Boolean } isFavourite - [Requires Login] Check if the media is favourited
  * @property { Boolean } isLicensed - Check if the media is licensed
+ * @property { Boolean } isLocked - Check if the media is locked for list additions or favouriting.
+ * @property { Boolean } isRecommendationBlocked - Check if the media is locked for recommendations.
  * @property { Number } meanScore - Mean score of the media
  * @property { Object } mediaListEntry - [Requires Login] User's media list entry; required for list edits.
  * @property { Number } mediaListEntry.id - Id of the media on a user's media list
@@ -228,6 +230,8 @@
  * @property { Boolean } isAdult - Check if the media is for adult audiences (ie: Hentai)
  * @property { Boolean } isFavourite - [Requires Login] Check if the media is favourited
  * @property { Boolean } isLicensed - Check if the media is licensed
+ * @property { Boolean } isLocked - Check if the media is locked for list additions or favouriting.
+ * @property { Boolean } isRecommendationBlocked - Check if the media is locked for recommendations.
  * @property { Number } meanScore - Mean score of the media
  * @property { Object } mediaListEntry - [Requires Login] User's media list entry; required for list edits.
  * @property { Number } mediaListEntry.id - Id of the media on a user's media list

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -153,13 +153,16 @@ module.exports = {
 				clearTimeout(requestTimeout);
 			});
 
-		let json;
-
-		try {
-			json = await response.json();
-		} catch (err) {
-			throw Error(err);
+		if (response.status !== 200) {
+			if (response.statusText) {
+				throw new Error(
+					`ERROR: AniList API returned with a ${response.status} error code. Message: ${response.statusText}`
+				);
+			}
+			throw new Error(`ERROR: AniList API returned with a ${response.status} error code.`);
 		}
+
+		const json = await response.json();
 
 		if (Object.keys(json).length < 0) {
 			throw new Error("ERROR: AniList API is down. Please refer to official channels for more information.");

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -673,7 +673,7 @@ export declare interface Trends {
     inProgress: number
 }
 
-export declare interface MediaEntry {
+declare interface MediaEntry {
     id: number,
     idMal: number,
     title: MediaTitle,


### PR DESCRIPTION
## Description
<!--
    Please include a general description of your changes.
    Be sure to mention if these changes removes or updates any queries with the API. Edits or removing properties in the queries could be deemed a breaking change.
-->

Fixed two issues:
1. Fixed the response catch for rate limiting. If response status is not equal to 200, the fetcher will throw an error.
2. Updated the JSDoc with missing properties (isRecommendationBlocked and isLocked) with AnimeEntry and MangaEntry responses.

Also includes a potential fix for a third issue. MediaEntry, which is a parent of AnimeEntry and MangaEntry in the typings, was getting returned for some anime functions. Updated the typing to not export MediaEntry as both AnimeEntry and MangaEntry are already exported.

## Related Issue
<!-- Include the GitHub issue if applicable -->

Internal#747, Internal#789, and Internal#790