### PR TITLE
feat:  add role data to staff media query

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -26,6 +26,10 @@ function edgeRemove(obj) {
 	for (let x = 0; x < obj.length; x++) {
 		if (obj[x].name) {
 			obj[x].name = obj[x].name.english || obj[x].name.full;
+		} else if (obj[x].role && obj[x].node?.id && obj[x].node?.name) {
+			obj[x].name = obj[x].node.name.english || obj[x].node.name.full;
+			obj[x].id = obj[x].node.id;
+			delete obj[x].node;
 		}
 
 		if (obj[x].node) {
@@ -66,7 +70,7 @@ function formatMedia(media) {
 
 	media.externalLinks = edgeRemove(media.externalLinks);
 	media.characters = edgeRemove(media.characters.nodes);
-	media.staff = edgeRemove(media.staff.nodes);
+	media.staff = edgeRemove(media.staff.edges);
 
 	if (media.airingSchedule) {
 		media.airingSchedule = media.airingSchedule.nodes;

--- a/lib/media.js
+++ b/lib/media.js
@@ -35,7 +35,7 @@ class Media {
             updatedAt coverImage { large:extraLarge medium:large small:medium color }
             bannerImage genres synonyms averageScore meanScore favourites
             popularity trending tags { id name isMediaSpoiler } relations { nodes { id title { english native romaji userPreferred } type } } 
-            characters { nodes { id name { english: full } } } staff { nodes { id name { english: full } } } studios { nodes { id name isAnimationStudio } } 
+            characters { nodes { id name { english: full } } } staff { edges { role node { id name { english: full } } } } studios { nodes { id name isAnimationStudio } } 
             isFavourite isAdult isLocked nextAiringEpisode { timeUntilAiring airingAt episode } airingSchedule { nodes { airingAt timeUntilAiring episode } }
             trends { nodes { date trending popularity inProgress } } externalLinks { url }
             streamingEpisodes { title thumbnail url site } rankings { rank type context year season } mediaListEntry { id status }
@@ -92,7 +92,7 @@ class Media {
             description format status startDate { year month day } endDate { year month day } chapters volumes countryOfOrigin isLicensed updatedAt
             coverImage { large:extraLarge medium:large small:medium color } bannerImage genres synonyms averageScore meanScore siteUrl autoCreateForumThread modNotes
             popularity trending tags { id name isMediaSpoiler } relations { nodes { id title { english native romaji userPreferred } type } }
-            characters { nodes { id name { english: full } } } staff { nodes { id name { english: full } } } isFavourite isAdult isLocked
+            characters { nodes { id name { english: full } } } staff { edges { role node { id name { english: full } } } } isFavourite isAdult isLocked
             trends { nodes { date trending popularity inProgress } } externalLinks { url } rankings { rank type context year season } 
             mediaListEntry { id status } reviews { nodes { id score summary body } } 
             stats { scoreDistribution { score amount } statusDistribution { status amount } } favourites

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -526,6 +526,10 @@ export declare interface PersonRelation {
     name: string
 }
 
+export declare interface PersonRoleRelation extends PersonRelation {
+	role: string
+}
+
 export declare interface UserRelation {
     id: number,
     name: string
@@ -741,7 +745,7 @@ declare interface MediaEntry {
     tags: Tags[],
     relations: MediaRelation[],
     characters: PersonRelation[],
-    staff: PersonRelation[],
+    staff: PersonRoleRelation[],
     studios: StudioRelation[],
     isFavourite: boolean,
     isAdult: boolean,


### PR DESCRIPTION
## Description
<!--
    Please include a general description of your changes.
    Be sure to mention if these changes removes or updates any queries with the API. Edits or removing properties in the queries could be deemed a breaking change.
-->

- Updated the `edgeRemove` function to handle `edges` (unstead `nodes`) roles and pass the necessary data for media query staff.
- Modified the `media query` for anime and manga to request data from the `edges`, getting the staff `role` and passing the `node` from the `edge` to get properly the ID and Name.