### PR TITLE
Fix incorrect default export in type declaration

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1319,4 +1319,4 @@ export declare interface AniListStats {
     reviews: DayStats[]
 }
 
-export default Anilist;
+export = Anilist;


### PR DESCRIPTION
## Description

The resolved types use `export default` where the JavaScript file appears to use `module.exports =`.

This will cause TypeScript under the `node16` module mode to think an extra `.default` property access is required, but that will likely fail at runtime.

These types should use `export =` instead of `export default`.

## Related Issue
Close #63 

## Other Information:
Reference:
https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md

Screenshot of the "Are the types wrong?" tool:
<img width="801" alt="Screenshot 2025-03-21 at 1 55 48 AM" src="https://github.com/user-attachments/assets/57a6d55f-97c0-4292-b424-a4cdabe2dc3c" />
